### PR TITLE
Add a README in the client/cordova directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,13 @@ To get the source code of our SDKs and samples via **git** just type:
     git clone https://github.com/Azure/azure-mobile-apps-quickstarts.git
     cd ./azure-mobile-apps-quickstarts/
  
-## Building Quickstarts For Uploading To Azure Portal
+## Quickstarts Usage Instructions
+
+The Azure Portal helps you get started quickly with Mobile Apps by providing a set of quickstarts for the supported client and server platforms. The quickstarts are customised by the Azure Portal to work with the Mobile App cloud backend you are downloading it for.
+
+Alternatively, you can build the quickstarts yourself for use with your Mobile Apps cloud backend.
+
+### Building Quickstarts For Uploading To Azure Portal
 
 From the command line, run 
 
@@ -28,28 +34,12 @@ From the command line, run
 
 The build script downloads latest official nuget packages, updates quickstarts with required versions and dependencies, and packs required projects to appropriate quickstarts.
 
-### Prerequisites
+#### Prerequisites
 
 .Net Framework 4.0.
 
-## Quickstarts Usage Instructions
+### Building And Using The Quickstarts Yourself
 
-### Cordova Client
+#### Cordova Client
 
-To use the Azure Mobile Apps Cordova client quickstart:
-
-  1. Edit ./client/cordova/ZUMOAPPNAME/www/js/index.js and replace the *ZUMOAPPURL* placeholder with your Mobile App URL.
-  2. Change to the Cordova quickstart directory:
-
-        cd ./client/cordova/ZUMOAPPNAME
-  3. Add the platform you want to build the quickstart for:
-
-        cordova platform add [android | ios | windows | wp8]
-  4. Run the quickstart:
-
-        cordova run [android | ios | windows | wp8]
-
-### Prerequisites
-
-* [Cordova CLI](https://cordova.apache.org/docs/en/latest/guide/cli/index.html)
-* Target platform SDK.
+To build the Azure Mobile Apps Cordova Client yourself, refer the [Cordova Client README](./client/cordova/README.md)

--- a/client/cordova/README.md
+++ b/client/cordova/README.md
@@ -1,0 +1,20 @@
+## Azure Mobile Apps Cordova Client Quickstart Instructions ##
+
+To use the quickstart:
+
+  1. Change to the Cordova quickstart directory:
+
+        cd ./ZUMOAPPNAME
+        
+  2. Edit ./www/js/index.js and replace the **_ZUMOAPPURL_** placeholder with your Mobile App cloud backend URL.
+  3. Add the platform you want to build the quickstart for:
+
+        cordova platform add [android | ios | windows | wp8]
+  4. Run the quickstart:
+
+        cordova run [android | ios | windows | wp8]
+
+### Prerequisites
+
+* [Cordova CLI](https://cordova.apache.org/docs/en/latest/guide/cli/index.html)
+* Target platform SDK.


### PR DESCRIPTION
- Added instructions to use the Cordova client to the client/cordova directory so that external links can directly link users to it.
- Instructions for building Quickstarts for uplaoding to the Azure portal continues to be in the root README.