### PR TITLE
Updated android sdk version

### DIFF
--- a/client/android/ZUMOAPPNAME/app/build.gradle
+++ b/client/android/ZUMOAPPNAME/app/build.gradle
@@ -29,6 +29,6 @@ dependencies {
     compile 'com.google.code.gson:gson:2.3'
     compile 'com.google.guava:guava:18.0'
 	compile 'com.squareup.okhttp:okhttp:2.5.0'
-    compile 'com.microsoft.azure:azure-mobile-services-android-sdk:3.0-Beta'
+    compile 'com.microsoft.azure:azure-mobile-android:3.0'
 	compile (group: 'com.microsoft.azure', name: 'azure-notifications-handler', version: '1.0.1', ext: 'jar')
 }


### PR DESCRIPTION
'com.microsoft.azure:azure-mobile-services-android-sdk:3.0-Beta' is not public and cannot be resolved.  This caused some confusion with customers who were cloning android quickstarts directly.  Changing to current Mobile Apps version for clarity.

Not sure how this interacts with the build/portal, @jwallra can you give it a quick check to make sure won't break our quickstart creation logic?