### PR TITLE
[UWP] Fixing some layout bugs for screen sizes <5in 

### DIFF
--- a/client/windows-uwp-cs/ZUMOAPPNAME/Common/QuickStartTask.xaml
+++ b/client/windows-uwp-cs/ZUMOAPPNAME/Common/QuickStartTask.xaml
@@ -6,7 +6,18 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d">
-    
+    <VisualStateManager.VisualStateGroups>
+        <VisualStateGroup>
+            <VisualState x:Name="large">
+                <VisualState.Setters>
+                    <Setter Target="DescriptionTextBox.(TextBox.MaxWidth)" Value="500"/>
+                </VisualState.Setters>
+                <VisualState.StateTriggers>
+                    <AdaptiveTrigger MinWindowWidth="500"/>
+                </VisualState.StateTriggers>
+            </VisualState>
+        </VisualStateGroup>
+    </VisualStateManager.VisualStateGroups>
     <Grid VerticalAlignment="Top">
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="Auto"/>
@@ -14,12 +25,12 @@
         </Grid.ColumnDefinitions>
         <Border Grid.Column="0" BorderThickness="0,0,1,0" BorderBrush="DarkGray" Margin="0,10,10,0" MinWidth="70"
                 Visibility="{x:Bind LayoutFormatVisibility}">
-            <TextBlock Text="{x:Bind Number, Mode=OneWay}" FontSize="45" Foreground="DarkGray" Margin="20,0"/>
+            <TextBlock Name="TaskNumberTextBox" Text="{x:Bind Number, Mode=OneWay}" FontSize="45" Foreground="DarkGray" Margin="20,0"/>
         </Border>
         <StackPanel Grid.Column="1">
-            <TextBlock Text="{x:Bind Title, Mode=OneWay}" Margin="0,10,0,0" HorizontalAlignment="Left" FontSize="16" FontWeight="Bold" TextWrapping="WrapWholeWords"
+            <TextBlock Name="TitleTextBox" Text="{x:Bind Title, Mode=OneWay}" Margin="0,10,0,0" HorizontalAlignment="Left" FontSize="16" FontWeight="Bold" TextWrapping="WrapWholeWords"
                         Visibility="{x:Bind LayoutFormatVisibility}"/>
-            <TextBlock Text="{x:Bind Description, Mode=OneWay}" HorizontalAlignment="Left" TextWrapping="WrapWholeWords" MaxWidth="500" />
+            <TextBlock Name="DescriptionTextBox" Text="{x:Bind Description, Mode=OneWay}" HorizontalAlignment="Left" TextWrapping="WrapWholeWords" MaxWidth="200" />
         </StackPanel>
     </Grid>
 </UserControl>

--- a/client/windows-uwp-cs/ZUMOAPPNAME/MainPage.xaml
+++ b/client/windows-uwp-cs/ZUMOAPPNAME/MainPage.xaml
@@ -18,8 +18,12 @@
                                 <Thickness>0,8,8,0</Thickness>
                             </Setter.Value>
                         </Setter>
+                        <Setter Target="TextInput.(TextBox.MinWidth)" Value="200"/>
+                        <Setter Target="TextInput.(TextBox.MaxWidth)" Value="200"/>
+                        <Setter Target="TextInput.(TextBox.HorizontalAlignment)" Value="Left"/>
                         <Setter Target="quickStartTask.(QuickStartTask.ShowMinimal)" Value="True"/>
                         <Setter Target="quickStartTaskQuery.(QuickStartTask.ShowMinimal)" Value="True"/>
+                        <Setter Target="ListItems.(CheckBox.Width)" Value="300"/>
                         <Setter Target="ItemsGrid.(Grid.Row)" Value="2"/>
                         <Setter Target="ItemsGrid.(Grid.Column)" Value="0"/>
                         <Setter Target="ItemsGrid.(Grid.ColumnSpan)" Value="2"/>
@@ -85,7 +89,7 @@
                     <local:QuickStartTask x:Name="quickStartTask" Number="1" Title="Insert a TodoItem" 
                                       Description="Enter some text below and click Save to insert a new todo item into your database" />
 
-                    <StackPanel Orientation="Horizontal">
+                    <StackPanel x:Name="addItemPanel" Orientation="Horizontal">
                         <TextBox Grid.Row="1" MinWidth="300" Margin="5,5,5,5" Name="TextInput" KeyDown="TextInput_KeyDown" Height="44"></TextBox>
                         <Button Name="ButtonSave" Grid.Row="1" Grid.Column="1" VerticalAlignment="Top" Margin="0,8,8,8" Click="ButtonSave_Click">
                             <StackPanel Orientation="Horizontal">
@@ -117,20 +121,19 @@
                     </Button>
                 </RelativePanel>
 
-                <ScrollViewer Grid.Row="1" Margin="62,10,0,0" 
+                <ScrollViewer Grid.Row="1" Margin="0,10,0,0" 
                               ScrollViewer.VerticalScrollBarVisibility="Visible" 
-                              VerticalAlignment="Stretch" HorizontalAlignment="Left">
+                              VerticalAlignment="Stretch" HorizontalAlignment="Stretch">
                     <ListView x:Name="ListItems">
                         <ListView.ItemTemplate>
                             <DataTemplate>
-                                <StackPanel Orientation="Horizontal">
-                                    <CheckBox x:Name="CheckBoxComplete" 
+                                <CheckBox x:Name="CheckBoxComplete" 
                                           IsChecked="{Binding Complete, Mode=TwoWay}" 
                                           Checked="CheckBoxComplete_Checked" 
-                                          Content="{Binding Text}" 
-                                          Width="550"
-                                          VerticalAlignment="Center"/>
-                                </StackPanel>
+                                          MaxWidth="550"
+                                          VerticalAlignment="Center">
+                                    <TextBlock Name="ItemText" Text="{Binding Text}" MaxWidth="550" HorizontalAlignment="Left" TextWrapping="WrapWholeWords"/>
+                                </CheckBox>
                             </DataTemplate>
                         </ListView.ItemTemplate>
                     </ListView>


### PR DESCRIPTION
Fixes issue #49. 

Modified layout to better adapt to small screen sizes. Fixed issue with lack of word wrap for TodoItems
![image](https://cloud.githubusercontent.com/assets/665865/15332235/a858896c-1c19-11e6-8f62-546ba73eae5e.png)
