### PR TITLE
Update android quickstart for Android SDK 3.2.0 release

### DIFF
--- a/client/android/ZUMOAPPNAME/app/build.gradle
+++ b/client/android/ZUMOAPPNAME/app/build.gradle
@@ -1,11 +1,10 @@
 apply plugin: 'com.android.application'
 android {
     compileSdkVersion 23
-    buildToolsVersion '23.0.0'
-
+    buildToolsVersion '25.0.0'
     defaultConfig {
         applicationId "com.example.zumoappname"
-        minSdkVersion 9
+        minSdkVersion 19
         targetSdkVersion 23
         versionCode 1
         versionName "1.0"
@@ -16,7 +15,6 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
-
     repositories {
         flatDir {
             dirs 'aars'
@@ -28,7 +26,7 @@ dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     compile 'com.google.code.gson:gson:2.3'
     compile 'com.google.guava:guava:18.0'
-	compile 'com.squareup.okhttp:okhttp:2.5.0'
-    compile 'com.microsoft.azure:azure-mobile-services-android-sdk:3.0'
-	compile (group: 'com.microsoft.azure', name: 'azure-notifications-handler', version: '1.0.1', ext: 'jar')
+    compile 'com.squareup.okhttp:okhttp:2.5.0'
+    compile 'com.microsoft.azure:azure-mobile-android:3.2.0@aar'
+    compile 'com.microsoft.azure:azure-notifications-handler:1.0.1@jar'
 }

--- a/client/android/ZUMOAPPNAME/build.gradle
+++ b/client/android/ZUMOAPPNAME/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.2'
+        classpath 'com.android.tools.build:gradle:2.3.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/client/android/ZUMOAPPNAME/gradle/wrapper/gradle-wrapper.properties
+++ b/client/android/ZUMOAPPNAME/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sun Jan 11 21:44:32 PST 2015
+#Wed Mar 22 09:39:07 PDT 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip


### PR DESCRIPTION
- Update android quickstart to use latest version of gradle tools
- Update android quickstart to pick up 'com.microsoft.azure:azure-mobile-android:3.2.0'