### PR TITLE
Add minimum android version to quickstart

### DIFF
--- a/client/cordova/ZUMOAPPNAME/config.xml
+++ b/client/cordova/ZUMOAPPNAME/config.xml
@@ -107,4 +107,5 @@
     <splash src="res/screens/wp8/SplashScreenImage.jpg" width="480" height="800" />
   </platform>
   <plugin name="cordova-plugin-ms-azure-mobile-apps" spec="~2.0.0" />
+  <preference name="android-minSdkVersion" value="19" />
 </widget>


### PR DESCRIPTION
So that it does not break on Cordova plugin 2.0.1+ at build time.