### PR TITLE
Fix templates for VS 2019

### DIFF
--- a/client/xamarin.android/ZUMOAPPNAME/ZUMOAPPNAME.tt
+++ b/client/xamarin.android/ZUMOAPPNAME/ZUMOAPPNAME.tt
@@ -22,7 +22,6 @@
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <AndroidUseLatestPlatformSdk>false</AndroidUseLatestPlatformSdk>
     <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
-    <AndroidSupportedAbis>armeabi,armeabi-v7a,x86</AndroidSupportedAbis>
     <AndroidStoreUncompressedFileExtensions />
     <MandroidI18n />
 	<Debugger>Xamarin</Debugger>
@@ -51,7 +50,6 @@
     <WarningLevel>4</WarningLevel>
     <AndroidUseSharedRuntime>false</AndroidUseSharedRuntime>
     <ConsolePause>false</ConsolePause>
-    <AndroidSupportedAbis>armeabi,armeabi-v7a</AndroidSupportedAbis>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Java.Interop" />

--- a/client/xamarin.forms/Droid/ZUMOAPPNAME.Droid.tt
+++ b/client/xamarin.forms/Droid/ZUMOAPPNAME.Droid.tt
@@ -19,11 +19,10 @@
     <AndroidUseLatestPlatformSdk>True</AndroidUseLatestPlatformSdk>
     <AssemblyName>ZUMOAPPNAME.Droid</AssemblyName>
     <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
-	<AndroidSupportedAbis>armeabi;armeabi-v7a;x86</AndroidSupportedAbis>
-	<AndroidLinkSkip>
-	</AndroidLinkSkip>
-	<AndroidStoreUncompressedFileExtensions>
-	</AndroidStoreUncompressedFileExtensions>
+    <AndroidLinkSkip>
+    </AndroidLinkSkip>
+    <AndroidStoreUncompressedFileExtensions>
+    </AndroidStoreUncompressedFileExtensions>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/client/xamarin.forms/ZUMOAPPNAME.tt
+++ b/client/xamarin.forms/ZUMOAPPNAME.tt
@@ -40,6 +40,7 @@ Global
 		{3AFA591D-C115-4AC9-9519-F788373ECDE9}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
 		{3AFA591D-C115-4AC9-9519-F788373ECDE9}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
 		{3AFA591D-C115-4AC9-9519-F788373ECDE9}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{3AFA591D-C115-4AC9-9519-F788373ECDE9}.Debug|x64.Build.0 = Debug|Any CPU
 		{3AFA591D-C115-4AC9-9519-F788373ECDE9}.Debug|x86.ActiveCfg = Debug|Any CPU
 		{3AFA591D-C115-4AC9-9519-F788373ECDE9}.Debug|x86.Build.0 = Debug|Any CPU
 		{3AFA591D-C115-4AC9-9519-F788373ECDE9}.Release|Any CPU.ActiveCfg = Release|Any CPU
@@ -50,6 +51,7 @@ Global
 		{3AFA591D-C115-4AC9-9519-F788373ECDE9}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
 		{3AFA591D-C115-4AC9-9519-F788373ECDE9}.Release|Mixed Platforms.Build.0 = Release|Any CPU
 		{3AFA591D-C115-4AC9-9519-F788373ECDE9}.Release|x64.ActiveCfg = Release|Any CPU
+		{3AFA591D-C115-4AC9-9519-F788373ECDE9}.Release|x64.Build.0 = Release|Any CPU
 		{3AFA591D-C115-4AC9-9519-F788373ECDE9}.Release|x86.ActiveCfg = Release|Any CPU
 		{3AFA591D-C115-4AC9-9519-F788373ECDE9}.Release|x86.Build.0 = Release|Any CPU
 		{5FA0219F-B063-4D07-800B-CC38BDB5B916}.Debug|Any CPU.ActiveCfg = Debug|iPhoneSimulator


### PR DESCRIPTION
Due to the [removal of armeabi support in Android NDK r17](https://developer.android.com/ndk/guides/abis), projects that have this old ABI selected in the `$(AndroidSupportedAbis)` property will need to be updated to remove it before they will build successfully with newer versions of Xamarin.Android.