### PR TITLE
chore(android): update Android to latest build

### DIFF
--- a/client/android/ZUMOAPPNAME/app/build.gradle
+++ b/client/android/ZUMOAPPNAME/app/build.gradle
@@ -31,7 +31,7 @@ dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation 'com.google.code.gson:gson:2.3'
     implementation 'com.google.guava:guava:18.0'
-    implementation 'com.squareup.okhttp:okhttp:2.5.0'
-    implementation 'com.microsoft.azure:azure-mobile-android:3.4.0@aar'
-    implementation 'com.microsoft.azure:azure-notifications-handler:1.0.1@jar'
+    implementation 'com.squareup.okhttp3:okhttp:3.12.1'
+    implementation 'com.microsoft.azure:azure-mobile-android:3.5.1@aar'
+    implementation 'com.microsoft.azure:azure-notifications-handler:3.5.1@jar'
 }

--- a/client/android/ZUMOAPPNAME/app/src/main/java/com/example/zumoappname/ToDoActivity.java
+++ b/client/android/ZUMOAPPNAME/app/src/main/java/com/example/zumoappname/ToDoActivity.java
@@ -39,7 +39,7 @@ import com.microsoft.windowsazure.mobileservices.table.sync.localstore.ColumnDat
 import com.microsoft.windowsazure.mobileservices.table.sync.localstore.MobileServiceLocalStoreException;
 import com.microsoft.windowsazure.mobileservices.table.sync.localstore.SQLiteLocalStore;
 import com.microsoft.windowsazure.mobileservices.table.sync.synchandler.SimpleSyncHandler;
-import com.squareup.okhttp.OkHttpClient;
+import okhttp3.OkHttpClient;
 
 import static com.microsoft.windowsazure.mobileservices.table.query.QueryOperations.*;
 
@@ -99,9 +99,11 @@ public class ToDoActivity extends Activity {
             mClient.setAndroidHttpClientFactory(new OkHttpClientFactory() {
                 @Override
                 public OkHttpClient createOkHttpClient() {
-                    OkHttpClient client = new OkHttpClient();
-                    client.setReadTimeout(20, TimeUnit.SECONDS);
-                    client.setWriteTimeout(20, TimeUnit.SECONDS);
+                    OkHttpClient client = new OkHttpClient.Builder()
+                            .connectTimeout(20, TimeUnit.SECONDS)
+                            .readTimeout(20, TimeUnit.SECONDS)
+                            .build();
+
                     return client;
                 }
             });


### PR DESCRIPTION
chore(android): update Android to latest build

Updates the following for the latest release:
- `com.microsoft.azure:azure-mobile-android` from `3.4.0` to `3.5.1`
- `com.microsoft.azure:azure-notifications-handler` from `1.0.1` to `3.5.1`
- `com.squareup.okhttp3` from `2.5.0` to `3.12.1`

Updates the `setAndroidHttpClientFactory` to implement an override using the `okhttp3.OkHttpClient` instead of the older `com.squareup.okhttp.OkHttpClient`