### PR TITLE
Android Client: Fix issue where on recent versions of Android, the app would fail to connect to Azure Mobile Services

### DIFF
--- a/client/android/ZUMOAPPNAME/app/src/main/AndroidManifest.xml
+++ b/client/android/ZUMOAPPNAME/app/src/main/AndroidManifest.xml
@@ -9,6 +9,7 @@
         android:allowBackup="true"
         android:icon="@drawable/ic_launcher"
         android:label="@string/app_name"
+        android:usesCleartextTraffic="true"
         android:theme="@style/AppTheme" >
 
         <activity android:name="ToDoActivity"


### PR DESCRIPTION
As of a recent Android version, this code would fail because non HTTPS traffic requires this manifest entry in order to be allowed to connect. As Azure services uses HTTP, they would be blocked by Android and would throw non-descriptive errors on clients running reasonably recent versions of Android.